### PR TITLE
Replace old kicad domain.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ along with Gerberoid.  If not, see <http://www.gnu.org/licenses/>.
 
 ---
 
-[1]: http://kicad-pcb.org/
+[1]: http://kicad.org/


### PR DESCRIPTION
The old kicad domain was sold out from under the project.  More info: https://forum.kicad.info/t/warning-avoid-all-links-to-kicad-pcb-org-use-kicad-org/31521
I also recommend updating the description to also point to the new domain.